### PR TITLE
Jump Added

### DIFF
--- a/My First Game Jam/Assets/Mckano/Mckano_Scene.unity
+++ b/My First Game Jam/Assets/Mckano/Mckano_Scene.unity
@@ -233,6 +233,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   movementSpeed: 300
+  jumpForce: 50
 --- !u!54 &511425778
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/My First Game Jam/Assets/Mckano/Scripts/Player_Movement.cs
+++ b/My First Game Jam/Assets/Mckano/Scripts/Player_Movement.cs
@@ -7,6 +7,7 @@ public class Player_Movement : MonoBehaviour
     Rigidbody rb;
 
     public float movementSpeed;
+    public float jumpForce;
 
     // Start is called before the first frame update
     void Start()
@@ -20,5 +21,23 @@ public class Player_Movement : MonoBehaviour
         float horizontal = Input.GetAxisRaw("Horizontal") * Time.deltaTime;
 
         rb.velocity = new Vector3(horizontal * movementSpeed, rb.velocity.y, rb.velocity.z);
+    }
+
+    private void Update()
+    {
+        Jump();
+    }
+    void Jump()
+    {
+        float maxRayDistance = (transform.localScale.y / 2) + 0.1f;
+        Vector3 offset = new Vector3(transform.localScale.x / 2, 0, 0);
+
+        if (Input.GetKeyDown(KeyCode.Space))
+        {
+            if (Physics.Raycast(transform.position + offset, Vector3.down, maxRayDistance))
+                rb.AddForce(0, jumpForce, 0);
+            else if (Physics.Raycast(transform.position - offset, Vector3.down, maxRayDistance))
+                rb.AddForce(0, jumpForce, 0);
+        }
     }
 }


### PR DESCRIPTION
Jump is based on player's size as it shoots a ray down and ray distance is the player's height divided by 2 + .01. this prevents double jumps by mistake.